### PR TITLE
Better compatibility with Rails remote methods

### DIFF
--- a/vendor/assets/javascripts/src/confirm.js
+++ b/vendor/assets/javascripts/src/confirm.js
@@ -3,7 +3,7 @@ document.addEventListener('click', function (event) {
 
   element = event.target;
 
-  if (matches.call(element, 'a[data-confirm], button[data-confirm]')) {
+  if (matches.call(element, 'a[data-confirm], button[data-confirm], input[data-confirm]')) {
     message = element.getAttribute('data-confirm');
     if (!confirm(message)) {
       event.stopPropagation();

--- a/vendor/assets/javascripts/src/dom.js
+++ b/vendor/assets/javascripts/src/dom.js
@@ -1,0 +1,3 @@
+Element.prototype.remove = function() {
+    this.parentElement.removeChild(this);
+}

--- a/vendor/assets/javascripts/src/dom.js
+++ b/vendor/assets/javascripts/src/dom.js
@@ -1,3 +1,0 @@
-Element.prototype.remove = function() {
-    this.parentElement.removeChild(this);
-}

--- a/vendor/assets/javascripts/src/form.js
+++ b/vendor/assets/javascripts/src/form.js
@@ -1,0 +1,20 @@
+document.addEventListener('submit', function(event) {
+
+  var form = event.target;
+
+  if (matches.call(form, 'form[data-remote]')) {
+    url = form.action;
+    method = form.method || form.getAttribute('data-method').toUpperCase() || 'POST';
+    data = new FormData(form);
+
+    if (CSRF.param() && CSRF.token()) {
+      data[CSRF.param()] = CSRF.token();
+    }
+
+    if (LiteAjax.ajax({ url: url, method: method, data: data })){
+      event.preventDefault();
+    } else {
+      return true;
+    }
+  }
+});

--- a/vendor/assets/javascripts/src/liteajax.js
+++ b/vendor/assets/javascripts/src/liteajax.js
@@ -3,8 +3,7 @@ var LiteAjax = (function () {
 
   LiteAjax.options = {
     method: 'GET',
-    url: window.location.href,
-    async: true,
+    url: window.location.href
   };
 
   LiteAjax.ajax = function (url, options) {
@@ -46,7 +45,8 @@ var LiteAjax = (function () {
       });
     }
 
-    xhr.open(options.method || 'GET', url, options.async);
+    xhr.open(options.method || 'GET', url);
+    xhr.setRequestHeader('X-Requested-With', 'XmlHttpRequest');
     var beforeSend = new CustomEvent('ajax:before', {detail: xhr});
     document.dispatchEvent(beforeSend);
     xhr.send(options.data);

--- a/vendor/assets/javascripts/src/liteajax.js
+++ b/vendor/assets/javascripts/src/liteajax.js
@@ -21,6 +21,11 @@ var LiteAjax = (function () {
     xhr = new XMLHttpRequest();
 
     xhr.addEventListener('load', function () {
+      responseType = xhr.getResponseHeader('content-type');
+      if(responseType === 'text/javascript; charset=utf-8') {
+        eval(xhr.response);
+      }
+
       var event = new CustomEvent('ajaxComplete', {detail: xhr});
       document.dispatchEvent(event);
     });

--- a/vendor/assets/javascripts/src/liteajax.js
+++ b/vendor/assets/javascripts/src/liteajax.js
@@ -14,6 +14,7 @@ var LiteAjax = (function () {
 
     options = options || {};
     url = url || options.url || location.href || '';
+    data = options.data;
 
     var xhr;
 
@@ -47,9 +48,15 @@ var LiteAjax = (function () {
 
     xhr.open(options.method || 'GET', url);
     xhr.setRequestHeader('X-Requested-With', 'XmlHttpRequest');
+
+    if(options.json) {
+      xhr.setRequestHeader('Content-type', 'application/json');
+      data = JSON.stringify(data)
+    }
+
     var beforeSend = new CustomEvent('ajax:before', {detail: xhr});
     document.dispatchEvent(beforeSend);
-    xhr.send(options.data);
+    xhr.send(data);
 
     return xhr;
   };


### PR DESCRIPTION
This is only a first feature proposal; I understand that the PR should be extended, cleaned up and covered with tests before it can be merged.

As I'm using [Server-Generated Javascript Responses](https://signalvnoise.com/posts/3697-server-generated-javascript-responses) to handle AJAX in my Rails apps, I expect vanilla-ujs to support that technique fully.

I've extended javascript with an ability to exeute response JS code; added support of `remote: true` in Rails-generated forms; fixed `ajax?` behaviour in triggered controller actions; added `data-confirm` support on `input` elements.
